### PR TITLE
Fix a build error on older giomm

### DIFF
--- a/gui/key_bindings.cpp
+++ b/gui/key_bindings.cpp
@@ -270,7 +270,7 @@ void KeyBindings::set_action_enabled(KeyBind p_bind, bool p_enabled) {
 
 void KeyBindings::set_action_checked(KeyBind p_bind, bool p_checked) {
 
-	actions[p_bind]->set_state(Glib::Variant<bool>::create(p_checked));
+	actions[p_bind]->change_state(Glib::Variant<bool>::create(p_checked));
 }
 void KeyBindings::set_action_state(KeyBind p_bind, const String &p_state) {
 
@@ -281,7 +281,7 @@ void KeyBindings::set_action_state(KeyBind p_bind, const String &p_state) {
 		idx = p_bind;
 	}
 
-	actions[idx]->set_state(Glib::Variant<Glib::ustring>::create(p_state.ascii().get_data()));
+	actions[idx]->change_state(Glib::Variant<Glib::ustring>::create(p_state.ascii().get_data()));
 }
 
 Glib::RefPtr<Gio::SimpleAction> KeyBindings::get_keybind_action(KeyBind p_bind) {


### PR DESCRIPTION
#7
Hi. This permits to build on a version of Glibmm which does not have `set_state` as a public method.
(Glibmm 2.50.0 on Debian stretch)
I just discover the program and didn't manage to test it fully, please check it for correctness.

More details:
- GNOME/glibmm@c5bed834d97fecc59c431fd87a2081a64007afee
- https://developer.gnome.org/gio/stable/GSimpleAction.html#g-simple-action-set-state
